### PR TITLE
Add Laracasts/Presenter to package dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*"
+        "illuminate/support": "5.0.*",
+        "laracasts/presenter": "0.1.*"
     },
 
     "autoload": {


### PR DESCRIPTION
BasePresenter class use Laracasts presenter package, while the latter isn't in composer.json
